### PR TITLE
Update m1_initial_schema.php

### DIFF
--- a/migrations/v31x/m1_initial_schema.php
+++ b/migrations/v31x/m1_initial_schema.php
@@ -95,7 +95,7 @@ class m1_initial_schema extends \phpbb\db\migration\migration
 					'COLUMNS'			=> array(
 						'id'			=> array('UINT', null, 'auto_increment'),
 						'time'			=> array('TIMESTAMP', 0),
-						'uname' 		=> array('VCHAR:25', ''),
+						'uname' 		=> array('VCHAR:255', ''),
 						'ugroup'		=> array('UINT:11', 0),
 						'agent' 		=> array('VCHAR:255', ''),
 						'ip_addr' 		=> array('VCHAR:50', ''),


### PR DESCRIPTION
Uname column should be varchar(255). Otherwise people which loginnames are longer than 25 characters cause an error ("Data too long for column 'uname' at row 1 [1407].") and can't login anymore. It should be 255 like in the username-column in phpbb_users.